### PR TITLE
fix(duckdb-wasm): CDNからWorkerをロードするように修正

### DIFF
--- a/app/routes/demo+/duckdb-wasm.order/route.tsx
+++ b/app/routes/demo+/duckdb-wasm.order/route.tsx
@@ -100,17 +100,28 @@ export default function OrderDemo({
               <input type="hidden" name="intent" value="sync" />
               <Button type="submit">Start / Resume Sync</Button>
             </Form>
-            {actionData?.result && (
-              <Badge
-                variant={
-                  actionData.result === 'synced' ? 'default' : 'secondary'
+          </HStack>
+
+          {actionData?.result && (
+            <div className="text-sm">
+              <span className="text-muted-foreground">Status: </span>
+              <span
+                className={
+                  actionData.result === 'synced'
+                    ? 'text-green-600'
+                    : 'text-yellow-600'
                 }
               >
                 {actionData.result}
-                {actionData.runId ? ` (${actionData.runId})` : ''}
-              </Badge>
-            )}
-          </HStack>
+              </span>
+              {actionData.runId && (
+                <>
+                  <span className="text-muted-foreground"> • Run ID: </span>
+                  <span className="font-mono text-xs">{actionData.runId}</span>
+                </>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION


`duckdb-wasm`の初期化処理を修正し、ローカルにバンドルされたファイルではなく、jsDelivr CDNからWorkerをロードするように変更しました。

#### 変更点

1.  **`db.client.ts`の修正**
    *   これまではViteの`?url` importを使って`duckdb-wasm`のWorkerとWASMファイルをローカルでバンドルしていました。これを`duckdb.getJsDelivrBundles()`を利用してCDNから取得する方式に変更しました。
    *   CDNから直接Workerを読み込む際のCORSエラーを回避するため、Workerスクリプトを`fetch`で取得し、`Blob`を生成して`URL.createObjectURL`で生成したURLを`Worker`コンストラクタに渡すようにしました。
    *   コンポーネントがアンマウントされる際に`URL.revokeObjectURL`を呼び出し、メモリリークを防ぐ処理を追加しました。

2.  **`route.tsx`のUI改善**
    *   データ同期のステータス表示を、より分かりやすいデザインに更新しました。
    *   `Badge`コンポーネントから、ステータスとRun IDを明確に区別して表示するテキストベースのUIに変更しました。

これにより、ビルドプロセスへの依存が減り、より安定した`duckdb-wasm`のセットアップが実現できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved database initialization reliability by loading DuckDB from a CDN and using a blob URL for the worker to prevent cross-origin loading issues.

- Style
  - Updated status display: moved to a separate text block with color-coded state (green for “synced”, yellow otherwise).
  - Run ID now shown on a separate line in monospace for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->