### PR TITLE
refactor: アップロードルートのDB操作をコロケーションファイルに抽出 & デッドコード削除

### DIFF
--- a/app/routes/demo/+conform.image-upload/mutations.ts
+++ b/app/routes/demo/+conform.image-upload/mutations.ts
@@ -1,0 +1,23 @@
+import { db } from '~/services/db.server'
+
+export const upsertUploadedFile = async (
+  key: string,
+  contentType: string | null,
+  size: number,
+) => {
+  return await db
+    .insertInto('uploadedFiles')
+    .values({ key, contentType, size })
+    .onConflict((oc) =>
+      oc.column('key').doUpdateSet({
+        contentType,
+        size,
+        updatedAt: new Date().toISOString(),
+      }),
+    )
+    .execute()
+}
+
+export const deleteUploadedFile = async (key: string) => {
+  return await db.deleteFrom('uploadedFiles').where('key', '=', key).execute()
+}

--- a/app/routes/demo/+conform.image-upload/queries.ts
+++ b/app/routes/demo/+conform.image-upload/queries.ts
@@ -1,0 +1,11 @@
+import { db } from '~/services/db.server'
+
+export const listUploadedFiles = async (limit = 100) => {
+  return await db
+    .selectFrom('uploadedFiles')
+    .select(['key', 'contentType', 'size', 'updatedAt'])
+    .where('key', 'like', 'uploads/%')
+    .orderBy('updatedAt', 'desc')
+    .limit(limit)
+    .execute()
+}

--- a/app/routes/demo/conform.image-upload-direct.tsx
+++ b/app/routes/demo/conform.image-upload-direct.tsx
@@ -27,7 +27,11 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui'
-import { db } from '~/services/db.server'
+import {
+  deleteUploadedFile,
+  upsertUploadedFile,
+} from './+conform.image-upload/mutations'
+import { listUploadedFiles } from './+conform.image-upload/queries'
 import type { Route } from './+types/conform.image-upload-direct'
 
 const uploadKeySchema = z.string().startsWith('uploads/')
@@ -44,13 +48,7 @@ const schema = z.discriminatedUnion('intent', [
 ])
 
 export const loader = async () => {
-  const files = await db
-    .selectFrom('uploadedFiles')
-    .select(['key', 'contentType', 'size', 'updatedAt'])
-    .where('key', 'like', 'uploads/%')
-    .orderBy('updatedAt', 'desc')
-    .limit(100)
-    .execute()
+  const files = await listUploadedFiles()
 
   const images = files.map((f) => ({
     key: f.key,
@@ -76,21 +74,11 @@ export const action = async ({ request }: Route.ActionArgs) => {
     )
     for (const { key, obj } of heads) {
       if (!obj) continue
-      await db
-        .insertInto('uploadedFiles')
-        .values({
-          key,
-          contentType: obj.httpMetadata?.contentType ?? null,
-          size: obj.size,
-        })
-        .onConflict((oc) =>
-          oc.column('key').doUpdateSet({
-            contentType: obj.httpMetadata?.contentType ?? null,
-            size: obj.size,
-            updatedAt: new Date().toISOString(),
-          }),
-        )
-        .execute()
+      await upsertUploadedFile(
+        key,
+        obj.httpMetadata?.contentType ?? null,
+        obj.size,
+      )
     }
     return dataWithSuccess(
       { lastResult: submission.reply({ resetForm: true }) },
@@ -104,10 +92,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   if (submission.value.intent === 'delete') {
     await Promise.all([
       env.R2.delete(submission.value.key),
-      db
-        .deleteFrom('uploadedFiles')
-        .where('key', '=', submission.value.key)
-        .execute(),
+      deleteUploadedFile(submission.value.key),
     ])
     return dataWithSuccess(
       {

--- a/app/routes/demo/conform.image-upload.tsx
+++ b/app/routes/demo/conform.image-upload.tsx
@@ -29,7 +29,11 @@ import {
   TableHeader,
   TableRow,
 } from '~/components/ui'
-import { db } from '~/services/db.server'
+import {
+  deleteUploadedFile,
+  upsertUploadedFile,
+} from './+conform.image-upload/mutations'
+import { listUploadedFiles } from './+conform.image-upload/queries'
 import type { Route } from './+types/conform.image-upload'
 
 const schema = z.discriminatedUnion('intent', [
@@ -44,13 +48,7 @@ const schema = z.discriminatedUnion('intent', [
 ])
 
 export const loader = async () => {
-  const files = await db
-    .selectFrom('uploadedFiles')
-    .select(['key', 'contentType', 'size', 'updatedAt'])
-    .where('key', 'like', 'uploads/%')
-    .orderBy('updatedAt', 'desc')
-    .limit(100)
-    .execute()
+  const files = await listUploadedFiles()
 
   const images = files.map((f) => ({
     key: f.key,
@@ -74,21 +72,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
     await env.R2.put(key, file, {
       httpMetadata: { contentType: file.type },
     })
-    await db
-      .insertInto('uploadedFiles')
-      .values({
-        key,
-        contentType: file.type,
-        size: file.size,
-      })
-      .onConflict((oc) =>
-        oc.column('key').doUpdateSet({
-          contentType: file.type,
-          size: file.size,
-          updatedAt: new Date().toISOString(),
-        }),
-      )
-      .execute()
+    await upsertUploadedFile(key, file.type, file.size)
     return dataWithSuccess(
       { lastResult: submission.reply({ resetForm: true }) },
       {
@@ -101,10 +85,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   if (submission.value.intent === 'delete') {
     await Promise.all([
       env.R2.delete(submission.value.key),
-      db
-        .deleteFrom('uploadedFiles')
-        .where('key', '=', submission.value.key)
-        .execute(),
+      deleteUploadedFile(submission.value.key),
     ])
     return dataWithSuccess(
       {

--- a/app/services/r2.server.ts
+++ b/app/services/r2.server.ts
@@ -97,21 +97,9 @@ async function uploadUrl(key: string): Promise<string> {
   return await generatePresignedUrl(key, 'PUT')
 }
 
-/**
- * ダウンロード用の Presigned URL (GET) を生成する
- * デフォルトで15分間有効
- * @param key オブジェクトキー (例: 'processed/image.png')
- * @returns ダウンロード用 Presigned URL 文字列
- * @throws Error R2 サービスの初期化に失敗した場合
- */
-async function downloadUrl(key: string): Promise<string> {
-  return await generatePresignedUrl(key, 'GET')
-}
-
 // --- エクスポート ---
 // サービスオブジェクトとしてまとめてエクスポート
 export const r2 = {
   generatePresignedUrl,
   uploadUrl,
-  downloadUrl, // GET 用も追加しておくと便利かも
 }


### PR DESCRIPTION
## Summary
- `+conform.image-upload/queries.ts` と `mutations.ts` を新規作成し、既存パターン（`+db.fts/`, `+db.sample_order/`）に統一
- 両アップロードルートのインラインDB操作を共有関数（`listUploadedFiles`, `upsertUploadedFile`, `deleteUploadedFile`）に置き換え
- 未使用の `r2.downloadUrl()` を削除

## Test plan
- [ ] `/demo/conform/image-upload` でアップロード・一覧・削除が正常に動作すること
- [ ] `/demo/conform/image-upload-direct` で直接アップロード・一覧・削除が正常に動作すること
- [ ] `pnpm validate` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed download URL generation capability from file upload services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->